### PR TITLE
Iss153 macosx mex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Auto-detect GMP at build and automatically disable if system libs missing.
   - Prefer Homebrew GMP; add its -I and -L flags when detected.
   - Make doc distclean portable: use Python utime instead of GNU touch -d.
+  - Fix `doc/Makefile` recipe parsing on macOS by using a portable, core-OS timestamp adjustment (no Python/Perl); removes a makefile syntax error during `make distclean`.
 
 * macOS-only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Change Log
 
 
+## [3.2.7-rc1] - 2025-12-08
+
+* Cross-platform
+
+  - Auto-detect GMP at build and automatically disable if system libs missing.
+  - Prefer Homebrew GMP; add its -I and -L flags when detected.
+  - Make doc distclean portable: use Python utime instead of GNU touch -d.
+
+* macOS-only
+
+  - Remove Linux-only -z noexecstack flag on Darwin to avoid linker errors.
+  - Default MACOSX_DEPLOYMENT_TARGET to SDK major version (e.g., 15.0) when unset, for consistent builds.
+  - Add Homebrew GMP -I/-L flags on macOS when detected so helpers link.
+
 ## [3.2.6] - 2025-08-02
 
 * Bugfix: Testsuite failed with Matlab R2025a because cell2mat no

--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,55 @@ else ifeq ($(SYS), Darwin)
 	endif
 endif
 
+# Set MACOSX deployment target to the major SDK version (e.g. 15.0) when on Darwin
+ifeq ($(SYS), Darwin)
+	SDKVER := $(shell xcrun --sdk macosx --show-sdk-version 2>/dev/null || echo)
+	ifneq ($(SDKVER),)
+		SDKMAJOR := $(firstword $(subst ., ,$(SDKVER)))
+		MACOSX_DEPLOYMENT_TARGET ?= $(SDKMAJOR).0
+	endif
+endif
+
 MEX = mex
 CFLAGS = -O -DMATLAB_MEX_FILE -fPIC
 # C++11 is needed for parallel code.
 CXXFLAGS = $(CFLAGS) -std=c++11
-MEXFLAGS = LDFLAGS='-z noexecstack' -largeArrayDims -O
+MEXFLAGS = -largeArrayDims -O
 
-# Use BRAIDLAB_USE_GMP=0 on command line to compile with GMP.
+# Modify MEXFLAGS to exclude unsupported flags on macOS
+ifeq ($(SYS), Darwin)
+	MEXFLAGS := $(filter-out LDFLAGS='-z noexecstack', $(MEXFLAGS))
+endif
+
+# Use BRAIDLAB_USE_GMP=0 on command line to disable GMP if desired.
+# If BRAIDLAB_USE_GMP is not set, try to detect available GMP libraries
+# and disable GMP automatically when they are not present. This avoids
+# failing the build on systems without libgmp / libgmpxx installed.
+ifndef BRAIDLAB_USE_GMP
+# Test by attempting to link a tiny program against gmpxx and gmp.
+# Use a one-line shell command that pipes source to the compiler to avoid
+# issues with multi-line heredocs inside make's $(shell ...).
+GMP_CHECK := $(shell printf 'int main(void){return 0;}' | cc -x c - -lgmpxx -lgmp -o /tmp/_braidlab_gmp_test 2>/dev/null && echo yes || echo no; rm -f /tmp/_braidlab_gmp_test 2>/dev/null)
+ifeq ($(GMP_CHECK),yes)
+	BRAIDLAB_USE_GMP = 1
+else
+	BRAIDLAB_USE_GMP = 0
+endif
+endif
+
 ifneq ($(BRAIDLAB_USE_GMP), 0)
-	GMP_LD = -lgmpxx -lgmp
+	# If Homebrew installed gmp, prefer its lib/include paths (Apple Silicon: /opt/homebrew)
+	BREW_GMP_PREFIX := $(shell brew --prefix gmp 2>/dev/null || echo)
+	ifneq ($(BREW_GMP_PREFIX),)
+		GMP_LD = -L$(BREW_GMP_PREFIX)/lib -lgmpxx -lgmp
+		CFLAGS += -I$(BREW_GMP_PREFIX)/include
+		CXXFLAGS += -I$(BREW_GMP_PREFIX)/include
+	else
+		GMP_LD = -lgmpxx -lgmp
+	endif
 	MEXFLAGS += -DBRAIDLAB_USE_GMP
+else
+	GMP_LD =
 endif
 
 MAKE = make MEX=$(MEX) MEXSUFFIX=$(MEXSUFFIX) MEXFLAGS="$(MEXFLAGS)" \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,7 +47,7 @@ clean:
 distclean: clean
 	# Revert PDF file to latest revision.
 	git checkout $(MASTERFILE).pdf
-	# Update timestamp so make knows to remake the file.
-	# Make pdf file 1 second older.
-	touch -r $(MASTERFILE).pdf -d '-1 second' $(MASTERFILE).pdf
+	# Update timestamp so make knows to remake the file. Use a single
+	# sh -c invocation to avoid multi-line continuation issues in make.
+	@sh -c 'os=$$(uname -s); if [ "$$os" = "Linux" ]; then touch -r "$(MASTERFILE).pdf" -d "-1 second" "$(MASTERFILE).pdf"; elif [ "$$os" = "Darwin" ]; then T=$$(stat -f %m "$(MASTERFILE).pdf"); Tprev=$$((T-1)); DATE=$$(date -r $$Tprev +%Y%m%d%H%M.%S); touch -t $$DATE "$(MASTERFILE).pdf"; else echo "Warning: unknown OS ($$os); PDF mtime not adjusted"; fi'
 	touch $(MASTERFILE).tex


### PR DESCRIPTION
Used Github Copilot to help resolve issues with Makefile compiling. If the PR is acceptable, I can then create the release binaries.

Changes were documented under CHANGELOG.md as the release candidate 3.2.7-rc1 (no substantive changes were made except to the `Makefile`).

On MATLAB 2024b the both with and without `gmp` the compile runs successfully. Matlab testsuite runs with one failing test (this can be addressed in a separate issue):

```
Running loopTest
..
================================================================================
Error occurred in loopTest/test_braid_test_mex and it did not run to completion.
    ---------
    Error ID:
    ---------
    'MATLAB:heterogeneousAssignment'
    --------------
    Error Details:
    --------------
    Assignment between unlike types is not allowed.
    
    Error in vpi/max (line 31)
        res(Y > X) = Y;
    
    Error in loopsigma>@(x)max(x,0) (line 130)
    pos = @(x)max(x,0); neg = @(x)min(x,0);
    
    Error in loopsigma (line 162)
          c = sumg( a(:,i-1), -a(:,i), -pos(b(:,i)), neg(b(:,i-1)) );
    
    Error in  *  (line 84)
        out = loopsigma(b1.word,b2.coords,b1.n);
    
    Error in loopTest/test_braid_test_mex (line 319)
            OUTmex = B*INmex;
================================================================================
```